### PR TITLE
Don't require i686 on aarch64

### DIFF
--- a/nixGL.nix
+++ b/nixGL.nix
@@ -12,8 +12,8 @@ nvidiaVersionFile ? null,
 # Enable 32 bits driver
 # This is one by default, you can switch it to off if you want to reduce a
 # bit the size of nixGL closure.
-enable32bits ? true
-, writeTextFile, shellcheck, pcre, runCommand, linuxPackages
+enable32bits ? stdenv.hostPlatform.isx86
+, stdenv, writeTextFile, shellcheck, pcre, runCommand, linuxPackages
 , fetchurl, lib, runtimeShell, bumblebee, libglvnd, vulkan-validation-layers
 , mesa, libvdpau-va-gl, intel-media-driver, pkgsi686Linux, driversi686Linux
 , zlib, libdrm, xorg, wayland, gcc }:


### PR DESCRIPTION
I didn't test this though.

@rollcat can you give this a shot?