### PR TITLE
Update nixGL for latest nixpkgs: nvidia kernel modules and package deprecations

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,9 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2.4.2
-    - uses: cachix/install-nix-action@v20
-    - uses: cachix/cachix-action@v12
+    - uses: actions/checkout@v7.0.0
+    - uses: cachix/install-nix-action@v31.10.7
+    - uses: cachix/cachix-action@v17
       with:
         name: guibou
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'

--- a/all.nix
+++ b/all.nix
@@ -1,7 +1,7 @@
 let
   pkgs = import ./nixpkgs.nix { config = { allowUnfree = true; }; };
 
-  pure = pkgs.recurseIntoAttrs (pkgs.callPackage ./nixGL.nix {
+  pure = pkgs.lib.recurseIntoAttrs (pkgs.callPackage ./nixGL.nix {
     nvidiaVersion = "440.82";
     nvidiaHash = "edd415acf2f75a659e0f3b4f27c1fab770cf21614e84a18152d94f0d004a758e";
   });

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746378225,
-        "narHash": "sha256-OeRSuL8PUjIfL3Q0fTbNJD/fmv1R+K2JAOqWJd3Oceg=",
+        "lastModified": 1783865431,
+        "narHash": "sha256-7u8oFt3pLdpmxGUJPvHiw+EwQGhoL8A4wbBja/dWYk4=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "93e8cdce7afc64297cfec447c311470788131cd9",
+        "rev": "1d2b03b1c775b7da6b9359ee5f20ad271f569042",
         "type": "github"
       },
       "original": {

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -87,7 +87,6 @@ let
 
       nvidiaLibsOnly = nvidiaDrivers.override {
         libsOnly = true;
-        kernel = null;
       };
 
       nixGLNvidiaBumblebee = writeExecutable {

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -16,7 +16,7 @@ enable32bits ? stdenv.hostPlatform.isx86
 , stdenv, writeTextFile, shellcheck, pcre, runCommand, linuxPackages
 , fetchurl, lib, runtimeShell, bumblebee, libglvnd, vulkan-validation-layers
 , mesa, libvdpau-va-gl, intel-media-driver, pkgsi686Linux, driversi686Linux
-, zlib, libdrm, xorg, wayland, gcc, zstd }:
+, zlib, libdrm, libx11, libxcb, libxshmfence, wayland, gcc, zstd }:
 
 let
   writeExecutable = { name, text }:
@@ -189,9 +189,9 @@ let
           lib.makeLibraryPath [
             zlib
             libdrm
-            xorg.libX11
-            xorg.libxcb
-            xorg.libxshmfence
+            libx11
+            libxcb
+            libxshmfence
             wayland
             gcc.cc
           ]

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -83,6 +83,18 @@ let
             builtins.fetchurl url;
           useGLVND = true;
           nativeBuildInputs = oldAttrs.nativeBuildInputs or [] ++ [zstd];
+          # Some driver releases (e.g. 510.54) ship both
+          # `libnvidia-compiler.so.<v>` and `libnvidia-compiler-next.so.<v>`,
+          # where the `-next` variant's SONAME equals the regular variant's
+          # filename.
+          # nixpkgs' nvidia-x11 installPhase then fails to
+          # `ln -s libnvidia-compiler-next.so.<v> libnvidia-compiler.so.<v>`
+          # because that path is already a real file. Therefore, drop
+          # redundant `-next` libraries (its SONAME points to the regular one
+          # anyway) so the symlink step has nothing to collide with.
+          postUnpack = (oldAttrs.postUnpack or "") + ''
+            rm -f libnvidia-compiler-next.so.*
+          '';
         });
 
       nvidiaLibsOnly = nvidiaDrivers.override {

--- a/nixGL.nix
+++ b/nixGL.nix
@@ -130,10 +130,12 @@ let
 
               ${
                 lib.optionalString (api == "Vulkan")
-                ''export VK_ICD_FILENAMES=${nvidiaLibsOnly}/share/vulkan/icd.d/nvidia_icd.x86_64.json${
+                ''NVIDIA_ICD=(${nvidiaLibsOnly}/share/vulkan/icd.d/*.json${
                   lib.optionalString enable32bits
-                  ":${nvidiaLibsOnly.lib32}/share/vulkan/icd.d/nvidia_icd.i686.json"
-                }"''${VK_ICD_FILENAMES:+:$VK_ICD_FILENAMES}"''
+                  " ${nvidiaLibsOnly.lib32}/share/vulkan/icd.d/*.json"
+                })
+                NVIDIA_ICD_FILENAMES=$(IFS=:; echo "''${NVIDIA_ICD[*]}")
+                export VK_ICD_FILENAMES="''${NVIDIA_ICD_FILENAMES}''${VK_ICD_FILENAMES:+:$VK_ICD_FILENAMES}"''
               }
               export LD_LIBRARY_PATH=${
                 lib.makeLibraryPath ([ libglvnd nvidiaLibsOnly ]

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,5 +1,5 @@
 let
-  rev = "4f6d8095fd51";
+  rev = "1d2b03b1c775b7da6b9359ee5f20ad271f569042";
 in
 import (fetchTarball {
   url = "https://github.com/nixos/nixpkgs/archive/${rev}.tar.gz";


### PR DESCRIPTION
In recent (unstable) nixpkgs, there have been changes to the nvidia kernel modules. So when you `inputs.nixpkgs.follows` nixGL's nixpkgs with unstable nixpkgs, you currently get

- evaluation warnings about the `xorg` package set and `recurseIntoAttrs`
- errors about the `kernel = null` override after NixOS/nixpkgs#498612
- errors about Vulkan ICDs not necessarily having the architecture in their filename

This PR fixes the evaluation warnings and the override error. Tested locally but I'm not quite sure if I have caught on to all necessary changes for current nixpkgs.

For the PR pipeline to succeed, I have bumped the `nixpkgs.nix` revision to match the flake `nixpkgs` pin and bumped a few GitHub actions.

There is one change I had to make for the pipeline to succeed where I'm not sure if it's correct: bbcc73c8bcc72b195fead993c7056b12683424f0. It's basically an SONAME collision between `libnvidia-compiler` and `libnvidia-compiler-next` and is probably a bug in the nixpkgs packaging of nvidia-x11 but I ran out of time to investigate.